### PR TITLE
fixed summer bootcamp description

### DIFF
--- a/events/summerbootcamp22/summerbootcamp.ts
+++ b/events/summerbootcamp22/summerbootcamp.ts
@@ -9,7 +9,7 @@ import {EVENT_STATUS, EventProps, SubEventProps} from "../../src/types/event_typ
 //         description: `# Summer Bootcamp '22
 //     ## _A bootcamp to help students kick start their journey with tech stacks like Android, Web development, etc._
 //
-//     **Summer Bootcamp '22** is a 4 week long bootcamp with various sessions to encourage HACKTOBERFEST in the community. It starts from June 4th and ends on June 26th.
+//     **Summer Bootcamp '22** is a 4 week long bootcamp with various sessions to encourage development in the community. It starts from June 4th and ends on June 26th.
 //     The event is open for every individual who is a beginner and wishes to learn about that specific tech stack.
 //
 //     ## What will happen in the BootCamp?

--- a/src/components/event/events.ts
+++ b/src/components/event/events.ts
@@ -137,7 +137,7 @@ Cerritus Coders is an inclusive community of students. We follow our code of con
         description: `
 ## _A bootcamp to help students kick start their journey with tech stacks like Android, Web development, etc._
 
-**Summer Bootcamp '22** is a 4 week long bootcamp with various sessions to encourage HACKTOBERFEST in the community. It starts from June 4th and ends on June 26th.
+**Summer Bootcamp '22** is a 4 week long bootcamp with various sessions to encourage development in the community. It starts from June 4th and ends on June 26th.
 The event is open for every individual who is a beginner and wishes to learn about that specific tech stack. 
 
 ## What will happen in the BootCamp?


### PR DESCRIPTION
# Description

accidentally put HACKTOBERFEST instead of development, changed it in this PR

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
